### PR TITLE
Add Objective-C interface + update to Swift 4

### DIFF
--- a/DeallocationChecker.xcodeproj/project.pbxproj
+++ b/DeallocationChecker.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				PRODUCT_NAME = DeallocationChecker;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -496,7 +496,7 @@
 				PRODUCT_NAME = DeallocationChecker;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Sources/DeallocationChecker.swift
+++ b/Sources/DeallocationChecker.swift
@@ -36,6 +36,16 @@ extension UIViewController {
         #endif
     }
 
+    @objc(dch_checkDeallocation)
+    public func objc_dch_checkDeallocation() {
+        self.dch_checkDeallocation()
+    }
+
+    @objc(dch_checkDeallocationAfterDelay:)
+    public func objc_dch_checkDeallocation(delay: TimeInterval) {
+        self.dch_checkDeallocation(afterDelay: delay)
+    }
+
     private var dch_rootParentViewController: UIViewController {
         var root = self
 


### PR DESCRIPTION
Thanks a lot for sharing this 👏 

We're starting to use this library in a mixed Obj-C/Swift project, therefore we added an Obj-C interface.

A bug in Swift 3.2 would require to annotate the original `dch_checkDeallocation` with `nonobjc`, therefore I updated to Swift 4.0 as part of this change.